### PR TITLE
feat: Add dynamic env vars interpolation in manifest.yml file

### DIFF
--- a/cmd/cli/dagger.go
+++ b/cmd/cli/dagger.go
@@ -74,7 +74,11 @@ stiletto job dagger --task-files=../../stiletto/tasks/terragrunt-plan.yml`,
 			}
 
 			// Task manifest, ready to be transformed into a valid Dagger job (task).
-			taskManifest, err := manifestBuilder.WithGeneratedTaskManifest().
+			taskManifest, err := manifestBuilder.
+				WithCompiledManifestStructure().
+				WithExtractedManifestContent().
+				WithCompiledManifestFunctions().
+				WithConstructedSpec().
 				WithStrictDeepValidation().
 				Build()
 

--- a/examples/tasks/dynamic-template-interpolation.yml
+++ b/examples/tasks/dynamic-template-interpolation.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Task
+metadata:
+    name: dynamic-template-interpolation-example-v1
+spec:
+    containerImage: alpine/terragrunt
+    mountDir: .
+    workdir: examples/terragrunt
+    envVarsSpec:
+        envVars:
+            PASSED_ENV_VAR_DYNAMICALLY: '{{ readEnv `MY_HOST_ENV_VAR` }}'
+    commandsSpec:
+        - binary:
+          commands:
+              - ls -ltrah /mnt
+        - binary:
+          commands:
+              - printenv
+              - echo my dynamically interpolated env var is {{ readEnv `MY_HOST_ENV_VAR` }}

--- a/internal/core/entities/constants.go
+++ b/internal/core/entities/constants.go
@@ -1,8 +1,39 @@
 package entities
 
+import (
+	"os"
+	"strings"
+	"text/template"
+)
+
 const ClientTypeCli = "CLI"
 const ManifestTypeTask = "MANIFEST_TASK"
 const ManifestTypeJob = "MANIFEST_JOB"
 const ManifestTypeWorkflow = "MANIFEST_WORKFLOW"
 
-//const ClientTypeApi = "API"
+type FunctionMap map[string]interface{}
+
+// TmplCfgFuncMaps is a map of template keywords and their respective functions.
+// It's used to map a specific word or keyword in a given manifes into
+// a function that will be executed by the template engine.
+var TmplCfgFuncMaps = map[string]template.FuncMap{
+	"readEnv": {
+		"readEnv": os.Getenv,
+	},
+	"pwd": {
+		"getPwd": os.Getwd,
+	},
+	"home": {
+		"getHome": os.UserHomeDir,
+	},
+	"replace": {
+		"replace": func(s, old, new string) string {
+			return strings.ReplaceAll(s, old, new)
+		},
+	},
+	"trimspace": {
+		"trimspace": func(s string) string {
+			return strings.TrimSpace(s)
+		},
+	},
+}

--- a/internal/core/manifest/templatekeywords.go
+++ b/internal/core/manifest/templatekeywords.go
@@ -1,0 +1,1 @@
+package manifest

--- a/internal/core/specs/taskspecbuilder.go
+++ b/internal/core/specs/taskspecbuilder.go
@@ -128,7 +128,7 @@ func (b *Builder) WithGeneratedTaskManifest() *Builder {
 
 	taskManifestSpec := &TaskManifestSpec{}
 
-	if err := yamlparser.YamlToStruct(b.manifestFile, taskManifestSpec); err != nil {
+	if err := yamlparser.YamlToStructFromFile(b.manifestFile, taskManifestSpec); err != nil {
 		errMsg := fmt.Sprintf("Cannot add task manifests, "+
 			"cannot parse yaml file %s", b.manifestFile)
 

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -103,3 +103,13 @@ func FindGitRepoDir(pathname string, levels int) (string, error) {
 	}
 	return "", fmt.Errorf("path %s is not a git repository", pathname)
 }
+
+// GetFileContent returns the content of a file as a string.
+func GetFileContent(filePath string) (string, error) {
+	contentBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading file %s: %v", filePath, err)
+	}
+
+	return string(contentBytes), nil
+}

--- a/internal/utils/templates.go
+++ b/internal/utils/templates.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+type TemplateCompilationOpts struct {
+	TemplateContent  string
+	TemplateFilePath string
+	Data             interface{}
+	TemplateName     string
+	FuncMap          template.FuncMap
+}
+
+// CompileTemplate compiles a text template with the given data and function map.
+// It returns the compiled template as a bytes.Buffer.
+func CompileTemplate(opts TemplateCompilationOpts) (bytes.Buffer, error) {
+	if opts.TemplateContent == "" && opts.TemplateFilePath == "" {
+		return bytes.Buffer{},
+			fmt.Errorf("both template content and template file path cannot be empty concurrently")
+	}
+
+	if opts.FuncMap == nil {
+		return bytes.Buffer{},
+			fmt.Errorf("FuncMap cannot be nil")
+	}
+
+	var content string
+	if opts.TemplateFilePath != "" {
+		file, err := os.ReadFile(opts.TemplateFilePath)
+		if err != nil {
+			return bytes.Buffer{}, fmt.Errorf("could not read the template file: %v", err)
+		}
+		content = string(file)
+	} else {
+		content = opts.TemplateContent
+	}
+
+	if opts.TemplateName == "" {
+		opts.TemplateName = "tmpl" // default name
+	}
+
+	if opts.Data == nil {
+		return bytes.Buffer{}, fmt.Errorf("data cannot be nil")
+	}
+
+	tmpl := template.New(opts.TemplateName).Funcs(opts.FuncMap)
+
+	tmpl, err := tmpl.Parse(content)
+	if err != nil {
+		return bytes.Buffer{}, fmt.Errorf("could not parse the template: %s", err)
+	}
+
+	var tpl bytes.Buffer
+
+	if err = tmpl.Execute(&tpl, opts.Data); err != nil {
+		return bytes.Buffer{}, fmt.Errorf("could not execute the template: %s", err)
+	}
+
+	return tpl, nil
+}

--- a/internal/utils/templates_test.go
+++ b/internal/utils/templates_test.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"text/template"
+)
+
+func TestCompileTemplate(t *testing.T) {
+	t.Run("should return error when both template content and template file path are empty", func(t *testing.T) {
+		opts := TemplateCompilationOpts{}
+		_, err := CompileTemplate(opts)
+
+		assert.Errorf(t, err, "both template content and template file path cannot be empty concurrently")
+	})
+
+	t.Run("should return error when FuncMap is nil", func(t *testing.T) {
+		opts := TemplateCompilationOpts{
+			TemplateContent: "some content",
+		}
+		_, err := CompileTemplate(opts)
+
+		assert.Errorf(t, err, "FuncMap cannot be nil")
+	})
+
+	t.Run("should return error when template file path is invalid", func(t *testing.T) {
+		opts := TemplateCompilationOpts{
+			TemplateFilePath: "some invalid path",
+			FuncMap:          template.FuncMap{},
+		}
+		_, err := CompileTemplate(opts)
+
+		assert.Errorf(t, err, "could not read the template file: open some invalid path: no such file or directory")
+	})
+
+	t.Run("should return error when data is nil", func(t *testing.T) {
+		opts := TemplateCompilationOpts{
+			TemplateContent: "some content",
+			FuncMap:         template.FuncMap{},
+		}
+		_, err := CompileTemplate(opts)
+
+		assert.Errorf(t, err, "data cannot be nil")
+	})
+
+	t.Run("should parse a template with an getEnv funcMap", func(t *testing.T) {
+		_ = os.Setenv("SHELL", "/bin/bash")
+
+		opts := TemplateCompilationOpts{
+			TemplateContent: "{{ getEnv \"SHELL\" }}",
+			FuncMap: template.FuncMap{
+				"getEnv": os.Getenv,
+			},
+			Data: make(map[string]string),
+		}
+
+		tplCompiled, err := CompileTemplate(opts)
+		tplCompiledStr := tplCompiled.String()
+
+		assert.NoErrorf(t, err, "could not compile the template: %s", err)
+		assert.NotNilf(t, tplCompiled, "template is nil")
+		assert.NotEmptyf(t, tplCompiledStr, "template is empty")
+	})
+
+	t.Run("should parse a more complex yaml file, with a getEnv funcMap", func(t *testing.T) {
+		_ = os.Setenv("SHELL", "/bin/bash")
+		_ = os.Setenv("HOME", "/home/user")
+		_ = os.Setenv("USER", "user")
+
+		// Define the template content with placeholders for environment variables
+		templateContent := `{
+		"shell": "{{ getEnv "SHELL" }}",
+		"home": "{{ getEnv "HOME" }}",
+		"user": "{{ getEnv "USER" }}"
+	}`
+
+		// Create the template compilation options
+		opts := TemplateCompilationOpts{
+			TemplateContent: templateContent,
+			FuncMap: template.FuncMap{
+				"getEnv": os.Getenv,
+			},
+			Data: make(map[string]string),
+		}
+
+		tpmCompiled, err := CompileTemplate(opts)
+		tplCompiledStr := tpmCompiled.String()
+
+		// Unmarshal the compiled template into the result struct
+		var resultStruct struct {
+			Shell string `json:"shell"`
+			Home  string `json:"home"`
+			User  string `json:"user"`
+		}
+
+		err = json.Unmarshal([]byte(tplCompiledStr), &resultStruct)
+
+		assert.NotNilf(t, tpmCompiled, "template is nil")
+		assert.NotEmptyf(t, tplCompiledStr, "template is empty")
+		assert.NoError(t, err, "could not compile the template: %s")
+		assert.Equal(t, "/bin/bash", resultStruct.Shell)
+		assert.Equal(t, "/home/user", resultStruct.Home)
+		assert.Equal(t, "user", resultStruct.User)
+	})
+}

--- a/internal/yamlparser/converter.go
+++ b/internal/yamlparser/converter.go
@@ -1,0 +1,51 @@
+package yamlparser
+
+import (
+	"bytes"
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"os"
+	"strings"
+)
+
+// YamlToStructFromFile converts a yaml file into a struct.
+func YamlToStructFromFile(yamlFile string, schema interface{}) error {
+	file, err := os.Open(yamlFile)
+
+	if err != nil {
+		return fmt.Errorf("could not open the yaml file: %s", err.Error())
+	}
+
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	if err := decoder.Decode(schema); err != nil {
+		return fmt.Errorf("the yaml file %s did not have a valid structure: %s", yamlFile, err.Error())
+	}
+
+	return nil
+}
+
+// YamlToStructWithContent converts a yaml file into a struct.
+func YamlToStructWithContent(yamlContent string, schema interface{}) error {
+	decoder := yaml.NewDecoder(strings.NewReader(yamlContent))
+	if err := decoder.Decode(schema); err != nil {
+		return fmt.Errorf("the yaml file did not have a valid structure: %s", err.Error())
+	}
+
+	return nil
+}
+
+// ConvertTemplateIntoYAML converts a template into a yaml file.
+func ConvertTemplateIntoYAML(tmpl bytes.Buffer) (interface{}, error) {
+	if tmpl.Len() == 0 {
+		return nil, fmt.Errorf("The template 'buffer' cannot be empty.")
+	}
+
+	var result interface{}
+	if err := yaml.Unmarshal(tmpl.Bytes(), &result); err != nil {
+		return nil, fmt.Errorf("could not unmarshal the template: %s", err)
+	}
+
+	return result, nil
+}

--- a/internal/yamlparser/validators.go
+++ b/internal/yamlparser/validators.go
@@ -49,21 +49,3 @@ func YamlStructureIsValid(yamlFile string, schema interface{}) error {
 
 	return nil
 }
-
-// YamlToStruct converts a yaml file into a struct.
-func YamlToStruct(yamlFile string, schema interface{}) error {
-	file, err := os.Open(yamlFile)
-
-	if err != nil {
-		return fmt.Errorf("could not open the yaml file: %s", err.Error())
-	}
-
-	defer file.Close()
-
-	decoder := yaml.NewDecoder(file)
-	if err := decoder.Decode(schema); err != nil {
-		return fmt.Errorf("the yaml file %s did not have a valid structure: %s", yamlFile, err.Error())
-	}
-
-	return nil
-}


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* 🎉 Now, adding `readEnv` and specific environment variables, allow Stiletto to cleverly construct dynamic and more versatile `tasks.yml` files

Example:
```
---
apiVersion: v1
kind: Task
metadata:
    name: dynamic-template-interpolation-example-v1
spec:
    containerImage: alpine/terragrunt
    mountDir: .
    workdir: examples/terragrunt
    envVarsSpec:
        envVars:
            PASSED_ENV_VAR_DYNAMICALLY: '{{ readEnv `MY_HOST_ENV_VAR` }}'
    commandsSpec:
        - binary:
          commands:
              - ls -ltrah /mnt
        - binary:
          commands:
              - printenv
              - echo my dynamically interpolated env var is {{ readEnv `MY_HOST_ENV_VAR` }}
```

## 📚 References
* ✅ closes #9 
