### PR TITLE
fix: avoid collision for reserved fucntions keywords

### DIFF
--- a/.github/workflows/semantic_pr.yaml
+++ b/.github/workflows/semantic_pr.yaml
@@ -45,7 +45,8 @@ jobs:
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
                   validateSingleCommit: true
-          # Configure additional validation for the subject based on a regex.
+                # yamllint disable-line rule:comments-indentation
+                # Configure additional validation for the subject based on a regex.
           # This ensures the subject doesn't start with an uppercase character.
                   subjectPattern: ^(?![A-Z]).+$
           # If `subjectPattern` is configured, you can use this property to override

--- a/examples/tasks/dynamic-template-interpolation.yml
+++ b/examples/tasks/dynamic-template-interpolation.yml
@@ -13,6 +13,7 @@ spec:
     commandsSpec:
         - binary:
           commands:
+              - pwd
               - ls -ltrah /mnt
         - binary:
           commands:

--- a/internal/core/entities/constants.go
+++ b/internal/core/entities/constants.go
@@ -20,18 +20,18 @@ var TmplCfgFuncMaps = map[string]template.FuncMap{
 	"readEnv": {
 		"readEnv": os.Getenv,
 	},
-	"pwd": {
+	"readPWD": {
 		"getPwd": os.Getwd,
 	},
-	"home": {
+	"readHome": {
 		"getHome": os.UserHomeDir,
 	},
-	"replace": {
+	"doReplace": {
 		"replace": func(s, old, new string) string {
 			return strings.ReplaceAll(s, old, new)
 		},
 	},
-	"trimspace": {
+	"doTrimspace": {
 		"trimspace": func(s string) string {
 			return strings.TrimSpace(s)
 		},


### PR DESCRIPTION
## 🎯 What
Fix that avoid collision in templates that includes as part of their content (E.g.: commands) words reserved for the stiletto functions, such as: `pwd`.

Example:
* 🔗 Closes #13 